### PR TITLE
Drop GPIO LED stuff for ReSpeaker Mic Array v2.0 (USB only).

### DIFF
--- a/interfaces/respeakerMicArrayV2.py
+++ b/interfaces/respeakerMicArrayV2.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from models.Exceptions 	import InterfaceInitError
-from gpiozero 			import LED
 from libraries 			import usb_pixel_ring_v2 	as pixel_ring
 from models.Interface 	import Interface
 
@@ -16,7 +15,6 @@ class RespeakerMicArrayV2(Interface):
 		if self._leds is None:
 			raise InterfaceInitError('Respeaker Mic Array V2 not found using pid={} and vid={}'.format(pid, vid))
 
-		self._power 	= LED(5)
 		self._colors 	= self._newArray()
 
 


### PR DESCRIPTION
I'm using SLC on x86 to control the ReSpeaker Mic Array v2.0 with usb interface. This PR drops the GPIO power LED stuff due to:
- the array already has a green power LED which gets enabled after starting SLC
- the GPIO stuff prevents SLC running on hosts without GPIO
