### PR TITLE
prevent addressing out of bound leds

### DIFF
--- a/models/Animations.py
+++ b/models/Animations.py
@@ -327,6 +327,8 @@ class Animations:
 
 	def _displayImage(self):
 		for i, led in enumerate(self._image):
+			if i >= self._numLeds:
+				break
 			self._controller.setLedRGB(i, led)
 
 		self._controller.show()


### PR DESCRIPTION
For example ProjectAlice: updating animation has an image with 5pixel, but respeaker2 can only display 3 pixel. None the less LED 4 is beeing set